### PR TITLE
(Fix) Include wildcard in cloud_trail cloud_watch_logs_group_arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,6 @@ resource "aws_cloudtrail" "cloudtrail" {
   include_global_service_events = true
   is_multi_region_trail         = true
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_logs_role.arn
-  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
+  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
   enable_log_file_validation    = true
 }


### PR DESCRIPTION
Throws error:
> Error: Error updating CloudTrail: InvalidCloudWatchLogsLogGroupArnException: Check the log group ARN: CloudTrail can't validate it.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#cloud_watch_logs_role_arn

> cloud_watch_logs_group_arn - (Optional) Specifies a log group name using an Amazon Resource Name (ARN), that represents the log group to which CloudTrail logs will be delivered. Note that CloudTrail requires the Log Stream wildcard.