### PR TITLE
(Fix) Add wildcard to cloudwatch log group arn in policy

### DIFF
--- a/policies/cloudtrail_cloudwatch_logs_policy.tpl
+++ b/policies/cloudtrail_cloudwatch_logs_policy.tpl
@@ -7,7 +7,7 @@
         "logs:CreateLogStream"
       ],
       "Resource": [
-        "${cloudwatch_log_group_arn}"
+        "${cloudwatch_log_group_arn}:*"
       ]
     },
     {
@@ -16,7 +16,7 @@
         "logs:PutLogEvents"
       ],
       "Resource": [
-        "${cloudwatch_log_group_arn}"
+        "${cloudwatch_log_group_arn}:*"
       ]
     }
   ]


### PR DESCRIPTION
The cloudwatch log group arn in the policy requires the wildcard added to the ARN, otherwise it produces an Access Denied error when trying to create the cloudtrail resource:

```
module.cloudtrail.aws_cloudtrail.cloudtrail: Creating...
module.cloudtrail.aws_cloudtrail.cloudtrail: Still creating... [10s elapsed]
module.cloudtrail.aws_cloudtrail.cloudtrail: Still creating... [20s elapsed]
module.cloudtrail.aws_cloudtrail.cloudtrail: Still creating... [30s elapsed]
module.cloudtrail.aws_cloudtrail.cloudtrail: Still creating... [40s elapsed]
module.cloudtrail.aws_cloudtrail.cloudtrail: Still creating... [50s elapsed]

Error: Error creating CloudTrail: InvalidCloudWatchLogsLogGroupArnException: Access denied. Check the permissions for your role.
```